### PR TITLE
Styled Footer and Added empty components and route handlers for footer links

### DIFF
--- a/client/src/CookiePolicy.js
+++ b/client/src/CookiePolicy.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 function CookiePolicy() {
-	return <div>CookiePolicy</div>;
+    return <div>CookiePolicy</div>;
 }
 
 export default CookiePolicy;

--- a/client/src/CookiePolicy.js
+++ b/client/src/CookiePolicy.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function CookiePolicy() {
+	return <div>CookiePolicy</div>;
+}
+
+export default CookiePolicy;

--- a/client/src/Footer.js
+++ b/client/src/Footer.js
@@ -1,24 +1,91 @@
+import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import FormControl from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+import FilledInput from '@material-ui/core/FilledInput';
+import Link from '@material-ui/core/Link';
+import TextField from '@material-ui/core/TextField';
+import FacebookIcon from '@material-ui/icons/Facebook';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import IconButton from '@material-ui/core/IconButton';
+import { makeStyles } from '@material-ui/core/styles';
+import StyledLink from './StyledLink';
+
+const useStyles = makeStyles((theme) => {
+	return {
+		main      : {
+			backgroundColor : '#C4C4C4',
+			padding         : theme.spacing(5)
+		},
+		linkBlock : {
+			'& > *' : {
+				marginBottom : theme.spacing(1)
+			}
+		},
+		header    : {
+			fontWeight : 'bold'
+		},
+		bottom    : {
+			marginTop : theme.spacing(4)
+		}
+	};
+});
+
 function Footer() {
-  return (
-    <div>
-      <div>
-        <span>Non-Profit Exchange Hub</span>
-        <span>Resources</span>
-        <span>About Us</span>
-        <span>How It Works</span>
-        <span>Our Story</span>
-        <span>Trust And Safety</span>
-        <span>Contact Us</span>
-        <span>Help & FAQs</span>
-      </div>
-      <div>
-        <span>NEH 2021</span>
-        <span>Terms of Service</span>
-        <span>Privacy Policy</span>
-        <span>Cookie Policy</span>
-      </div>
-    </div>
-  );
+	const classes = useStyles();
+
+	return (
+		<footer className="Footer">
+			<Grid className={classes.main} container>
+				<Grid container xs={12}>
+					<Grid
+						className={classes.linkBlock}
+						container
+						item
+						xs={6}
+						direction="column"
+						alignItems="flex-start"
+					>
+						<Typography className={classes.header} align="left" gutterBottom>
+							Non-Profit Exchange Hub
+						</Typography>
+						<StyledLink to="/about_us">About Us</StyledLink>
+						<StyledLink to="/our_story">Our Story</StyledLink>
+						<StyledLink to="/contact_us">Contact Us</StyledLink>
+					</Grid>
+					<Grid
+						className={classes.linkBlock}
+						container
+						item
+						xs={6}
+						direction="column"
+						alignItems="flex-start"
+					>
+						<Typography className={classes.header} align="left" gutterBottom>
+							Resources
+						</Typography>
+						<StyledLink to="/how_it_works">How It Works</StyledLink>
+						<StyledLink to="/trust_and_safety">Trust and Safety</StyledLink>
+						<StyledLink to="/help">Help & FAQs</StyledLink>
+					</Grid>
+				</Grid>
+				<Grid className={classes.bottom} container item md={8} xs={10} justify="space-between">
+					{/* TODO Not sure if NEH 2021 is supposed to just be text, or a link.
+          Leaving as text for now, as the name seems like it is changing anyway.*/}
+					<span>NEH 2021</span>
+					<StyledLink to="/terms_of_service">Terms of Service</StyledLink>
+					<StyledLink to="/privacy_policy">Privacy Policy</StyledLink>
+					<StyledLink to="/cookie_policy">Cookie Policy</StyledLink>
+				</Grid>
+			</Grid>
+		</footer>
+	);
 }
 
 export default Footer;

--- a/client/src/Footer.js
+++ b/client/src/Footer.js
@@ -1,91 +1,78 @@
 import React from 'react';
-import { Link as RouterLink } from 'react-router-dom';
-import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
-import Button from '@material-ui/core/Button';
-import FormControl from '@material-ui/core/FormControl';
-import InputLabel from '@material-ui/core/InputLabel';
-import FilledInput from '@material-ui/core/FilledInput';
-import Link from '@material-ui/core/Link';
-import TextField from '@material-ui/core/TextField';
-import FacebookIcon from '@material-ui/icons/Facebook';
-import Visibility from '@material-ui/icons/Visibility';
-import VisibilityOff from '@material-ui/icons/VisibilityOff';
-import InputAdornment from '@material-ui/core/InputAdornment';
-import IconButton from '@material-ui/core/IconButton';
 import { makeStyles } from '@material-ui/core/styles';
 import StyledLink from './StyledLink';
 
 const useStyles = makeStyles((theme) => {
-	return {
-		main      : {
-			backgroundColor : '#C4C4C4',
-			padding         : theme.spacing(5)
-		},
-		linkBlock : {
-			'& > *' : {
-				marginBottom : theme.spacing(1)
-			}
-		},
-		header    : {
-			fontWeight : 'bold'
-		},
-		bottom    : {
-			marginTop : theme.spacing(4)
-		}
-	};
+    return {
+        main      : {
+            backgroundColor : '#C4C4C4',
+            padding         : theme.spacing(5)
+        },
+        linkBlock : {
+            '& > *' : {
+                marginBottom : theme.spacing(1)
+            }
+        },
+        header    : {
+            fontWeight : 'bold'
+        },
+        bottom    : {
+            marginTop : theme.spacing(4)
+        }
+    };
 });
 
 function Footer() {
-	const classes = useStyles();
+    const classes = useStyles();
 
-	return (
-		<footer className="Footer">
-			<Grid className={classes.main} container>
-				<Grid container xs={12}>
-					<Grid
-						className={classes.linkBlock}
-						container
-						item
-						xs={6}
-						direction="column"
-						alignItems="flex-start"
-					>
-						<Typography className={classes.header} align="left" gutterBottom>
-							Non-Profit Exchange Hub
-						</Typography>
-						<StyledLink to="/about_us">About Us</StyledLink>
-						<StyledLink to="/our_story">Our Story</StyledLink>
-						<StyledLink to="/contact_us">Contact Us</StyledLink>
-					</Grid>
-					<Grid
-						className={classes.linkBlock}
-						container
-						item
-						xs={6}
-						direction="column"
-						alignItems="flex-start"
-					>
-						<Typography className={classes.header} align="left" gutterBottom>
-							Resources
-						</Typography>
-						<StyledLink to="/how_it_works">How It Works</StyledLink>
-						<StyledLink to="/trust_and_safety">Trust and Safety</StyledLink>
-						<StyledLink to="/help">Help & FAQs</StyledLink>
-					</Grid>
-				</Grid>
-				<Grid className={classes.bottom} container item md={8} xs={10} justify="space-between">
-					{/* TODO Not sure if NEH 2021 is supposed to just be text, or a link.
-          Leaving as text for now, as the name seems like it is changing anyway.*/}
-					<span>NEH 2021</span>
-					<StyledLink to="/terms_of_service">Terms of Service</StyledLink>
-					<StyledLink to="/privacy_policy">Privacy Policy</StyledLink>
-					<StyledLink to="/cookie_policy">Cookie Policy</StyledLink>
-				</Grid>
-			</Grid>
-		</footer>
-	);
+    return (
+        <footer className="Footer">
+            <Grid className={classes.main} container>
+                <Grid container xs={12}>
+                    <Grid
+                        className={classes.linkBlock}
+                        container
+                        item
+                        xs={6}
+                        direction="column"
+                        alignItems="flex-start"
+                    >
+                        <Typography className={classes.header} align="left" gutterBottom>
+                            Non-Profit Exchange Hub
+                        </Typography>
+                        <StyledLink to="/about_us">About Us</StyledLink>
+                        <StyledLink to="/our_story">Our Story</StyledLink>
+                        <StyledLink to="/contact_us">Contact Us</StyledLink>
+                    </Grid>
+                    <Grid
+                        className={classes.linkBlock}
+                        container
+                        item
+                        xs={6}
+                        direction="column"
+                        alignItems="flex-start"
+                    >
+                        <Typography className={classes.header} align="left" gutterBottom>
+                            Resources
+                        </Typography>
+                        <StyledLink to="/how_it_works">How It Works</StyledLink>
+                        <StyledLink to="/trust_and_safety">Trust and Safety</StyledLink>
+                        <StyledLink to="/help">Help & FAQs</StyledLink>
+                    </Grid>
+                </Grid>
+                <Grid className={classes.bottom} container item md={8} xs={10} justify="space-between">
+                    {/* TODO Not sure if NEH 2021 is supposed to just be text, or a link.
+                    Leaving as text for now, as the name seems like it is changing anyway.*/}
+                    <span>NEH 2021</span>
+                    <StyledLink to="/terms_of_service">Terms of Service</StyledLink>
+                    <StyledLink to="/privacy_policy">Privacy Policy</StyledLink>
+                    <StyledLink to="/cookie_policy">Cookie Policy</StyledLink>
+                </Grid>
+            </Grid>
+        </footer>
+    );
 }
 
 export default Footer;

--- a/client/src/Help.js
+++ b/client/src/Help.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 function Help() {
-	return <div>Help</div>;
+    return <div>Help</div>;
 }
 
 export default Help;

--- a/client/src/Help.js
+++ b/client/src/Help.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Help() {
+	return <div>Help</div>;
+}
+
+export default Help;

--- a/client/src/OurStory.js
+++ b/client/src/OurStory.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function OurStory() {
+	return <div>OurStory</div>;
+}
+
+export default OurStory;

--- a/client/src/OurStory.js
+++ b/client/src/OurStory.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 function OurStory() {
-	return <div>OurStory</div>;
+    return <div>OurStory</div>;
 }
 
 export default OurStory;

--- a/client/src/PrivacyPolicy.js
+++ b/client/src/PrivacyPolicy.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 function PrivacyPolicy() {
-	return <div>PrivacyPolicy</div>;
+    return <div>PrivacyPolicy</div>;
 }
 
 export default PrivacyPolicy;

--- a/client/src/PrivacyPolicy.js
+++ b/client/src/PrivacyPolicy.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function PrivacyPolicy() {
+	return <div>PrivacyPolicy</div>;
+}
+
+export default PrivacyPolicy;

--- a/client/src/Routes.js
+++ b/client/src/Routes.js
@@ -9,7 +9,12 @@ import AboutUs from './AboutUs';
 import ContactUs from './ContactUs';
 import LibraryAndForum from './LibraryAndForum';
 import HowItWorks from './HowItWorks';
-
+import TrustAndSafety from './TrustAndSafety';
+import OurStory from './OurStory';
+import Help from './Help';
+import TermsOfService from './TermsOfService';
+import PrivacyPolicy from './PrivacyPolicy';
+import CookiePolicy from './CookiePolicy';
 
 function Routes() {
 	return (
@@ -40,6 +45,24 @@ function Routes() {
 			</Route>
 			<Route exact path="/contact_us">
 				<ContactUs />
+			</Route>
+			<Route exact path="/our_story">
+				<OurStory />
+			</Route>
+			<Route exact path="/trust_and_safety">
+				<TrustAndSafety />
+			</Route>
+			<Route exact path="/help">
+				<Help />
+			</Route>
+			<Route exact path="/terms_of_service">
+				<TermsOfService />
+			</Route>
+			<Route exact path="/privacy_policy">
+				<PrivacyPolicy />
+			</Route>
+			<Route exact path="/cookie_policy">
+				<CookiePolicy />
 			</Route>
 		</Switch>
 	);

--- a/client/src/Routes.js
+++ b/client/src/Routes.js
@@ -17,55 +17,55 @@ import PrivacyPolicy from './PrivacyPolicy';
 import CookiePolicy from './CookiePolicy';
 
 function Routes() {
-	return (
-		<Switch>
-			<Route exact path="/">
-				<Home />
-			</Route>
-			<Route exact path="/login">
-				<Login />
-			</Route>
-			<Route exact path="/signup">
-				<Signup />
-			</Route>
-			<Route exact path="/signup_citizen">
-				<SignupCitizen />
-			</Route>
-			<Route exact path="/signup_nonprofit">
-				<SignupNonProfit />
-			</Route>
-			<Route exact path="/about_us">
-				<AboutUs />
-			</Route>
-			<Route exact path="/how_it_works">
-				<HowItWorks />
-			</Route>
-			<Route exact path="/library_and_forum">
-				<LibraryAndForum />
-			</Route>
-			<Route exact path="/contact_us">
-				<ContactUs />
-			</Route>
-			<Route exact path="/our_story">
-				<OurStory />
-			</Route>
-			<Route exact path="/trust_and_safety">
-				<TrustAndSafety />
-			</Route>
-			<Route exact path="/help">
-				<Help />
-			</Route>
-			<Route exact path="/terms_of_service">
-				<TermsOfService />
-			</Route>
-			<Route exact path="/privacy_policy">
-				<PrivacyPolicy />
-			</Route>
-			<Route exact path="/cookie_policy">
-				<CookiePolicy />
-			</Route>
-		</Switch>
-	);
+    return (
+        <Switch>
+            <Route exact path="/">
+                <Home />
+            </Route>
+            <Route exact path="/login">
+                <Login />
+            </Route>
+            <Route exact path="/signup">
+                <Signup />
+            </Route>
+            <Route exact path="/signup_citizen">
+                <SignupCitizen />
+            </Route>
+            <Route exact path="/signup_nonprofit">
+                <SignupNonProfit />
+            </Route>
+            <Route exact path="/about_us">
+                <AboutUs />
+            </Route>
+            <Route exact path="/how_it_works">
+                <HowItWorks />
+            </Route>
+            <Route exact path="/library_and_forum">
+                <LibraryAndForum />
+            </Route>
+            <Route exact path="/contact_us">
+                <ContactUs />
+            </Route>
+            <Route exact path="/our_story">
+                <OurStory />
+            </Route>
+            <Route exact path="/trust_and_safety">
+                <TrustAndSafety />
+            </Route>
+            <Route exact path="/help">
+                <Help />
+            </Route>
+            <Route exact path="/terms_of_service">
+                <TermsOfService />
+            </Route>
+            <Route exact path="/privacy_policy">
+                <PrivacyPolicy />
+            </Route>
+            <Route exact path="/cookie_policy">
+                <CookiePolicy />
+            </Route>
+        </Switch>
+    );
 }
 
 export default Routes;

--- a/client/src/StyledLink.js
+++ b/client/src/StyledLink.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import Link from '@material-ui/core/Link';
+import { makeStyles } from '@material-ui/core/styles';
+
+/**
+ * Styled Link with RouterLink set as component for Browser Router.
+ * Sets links to have black text, and default behavior of showing line on hover.
+ */
+const useStyles = makeStyles((theme) => {
+	return {
+		link : {
+			color     : '#000000',
+			textAlign : 'left'
+		}
+	};
+});
+
+function StyledLink(props) {
+	const classes = useStyles();
+
+	return (
+		<Link className={classes.link} component={RouterLink} to={props.to}>
+			{props.children}
+		</Link>
+	);
+}
+
+export default StyledLink;

--- a/client/src/StyledLink.js
+++ b/client/src/StyledLink.js
@@ -7,23 +7,24 @@ import { makeStyles } from '@material-ui/core/styles';
  * Styled Link with RouterLink set as component for Browser Router.
  * Sets links to have black text, and default behavior of showing line on hover.
  */
-const useStyles = makeStyles((theme) => {
-	return {
-		link : {
-			color     : '#000000',
-			textAlign : 'left'
-		}
-	};
+
+const useStyles = makeStyles(() => {
+    return {
+        link : {
+            color     : '#000000',
+            textAlign : 'left'
+        }
+    };
 });
 
 function StyledLink(props) {
-	const classes = useStyles();
+    const classes = useStyles();
 
-	return (
-		<Link className={classes.link} component={RouterLink} to={props.to}>
-			{props.children}
-		</Link>
-	);
+    return (
+        <Link className={classes.link} component={RouterLink} to={props.to}>
+            {props.children}
+        </Link>
+    );
 }
 
 export default StyledLink;

--- a/client/src/TermsOfService.js
+++ b/client/src/TermsOfService.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 function TermsOfService() {
-	return <div>TermsOfService</div>;
+    return <div>TermsOfService</div>;
 }
 
 export default TermsOfService;

--- a/client/src/TermsOfService.js
+++ b/client/src/TermsOfService.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function TermsOfService() {
+	return <div>TermsOfService</div>;
+}
+
+export default TermsOfService;

--- a/client/src/TrustAndSafety.js
+++ b/client/src/TrustAndSafety.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function TrustAndSafety() {
+	return <div>TrustAndSafety</div>;
+}
+
+export default TrustAndSafety;

--- a/client/src/TrustAndSafety.js
+++ b/client/src/TrustAndSafety.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 function TrustAndSafety() {
-	return <div>TrustAndSafety</div>;
+    return <div>TrustAndSafety</div>;
 }
 
 export default TrustAndSafety;


### PR DESCRIPTION
- Styled `<Footer>` to match Figma wireframe
- Added empty components for each of the footer links that didn't exist yet
- Created `<Route>` for each new empty component
- Created `<StyledLink>` component, which takes a `to` prop that sets the href, and is wrapped around text that will be the display text for the link. Currently this component sets the Material-UI Link to use `react-router-dom` Link (imported as `RouterLink` to avoid conflict with Material-UI Link), and add some simple styling that seemed consistent across the wireframes: black color, line on hover, and text aligned to left (only mattered at very small screen sizes).

![FooterChanges](https://user-images.githubusercontent.com/60631176/118422458-1b94cf00-b678-11eb-8a1c-55f5ba9f1bc2.PNG)
