### PR TITLE
offer page

### DIFF
--- a/client/src/Assets.tsx
+++ b/client/src/Assets.tsx
@@ -10,23 +10,10 @@ import Button from '@material-ui/core/Button';
 
 import NeedsAndOffers from './NeedsAndOffers';
 import FilterGroup from './FilterGroup';
+import { dumbyData, filters1, filters2, filters3 } from './assets/temp';
 
 import type { Theme } from '@material-ui/core/styles';
-import type { Asset as AssetT } from './types';
 
-
-const placeholderImg = 'https://optinmonster.com/wp-content/uploads/2019/09/nonprofit-newsletter.png';
-const dumbyData: AssetT[] = [1, 2, 3].map(num => ({
-    id: num,
-    title: `title ${num}`,
-    category: `category ${num}`,
-    datePosted: `datePosted ${num}`,
-    location: `location ${num}`,
-    img: placeholderImg,
-}));
-const filters1 = ['filter 1', 'filter 2', 'filter 3'];
-const filters2 = ['filter 4', 'filter 5', 'filter 6'];
-const filters3 = ['filter 7', 'filter 8', 'filter 9'];
 
 const useStyles = makeStyles((theme: Theme) => ({
     searchBar: {

--- a/client/src/Assets.tsx
+++ b/client/src/Assets.tsx
@@ -12,11 +12,11 @@ import NeedsAndOffers from './NeedsAndOffers';
 import FilterGroup from './FilterGroup';
 
 import type { Theme } from '@material-ui/core/styles';
-import type { Assets as AssetsT } from './types';
+import type { Asset as AssetT } from './types';
 
 
 const placeholderImg = 'https://optinmonster.com/wp-content/uploads/2019/09/nonprofit-newsletter.png';
-const dumbyData: AssetsT = [1, 2, 3].map(num => ({
+const dumbyData: AssetT[] = [1, 2, 3].map(num => ({
     id: num,
     title: `title ${num}`,
     category: `category ${num}`,

--- a/client/src/Home.tsx
+++ b/client/src/Home.tsx
@@ -16,11 +16,11 @@ import { NavLink } from 'react-router-dom';
 import NeedsAndOffers from './NeedsAndOffers';
 
 import type { Theme } from '@material-ui/core/styles';
-import type { Assets } from './types';
+import type { Asset } from './types';
 
 
 const placeholderImg = 'https://optinmonster.com/wp-content/uploads/2019/09/nonprofit-newsletter.png';
-const dumbyData: Assets = [1, 2, 3].map(num => ({
+const dumbyData: Asset[] = [1, 2, 3].map(num => ({
     id: num,
     title: `title ${num}`,
     category: `category ${num}`,

--- a/client/src/Home.tsx
+++ b/client/src/Home.tsx
@@ -14,20 +14,10 @@ import AccordionDetails from '@material-ui/core/AccordionDetails';
 import { NavLink } from 'react-router-dom';
 
 import NeedsAndOffers from './NeedsAndOffers';
+import { dumbyData, placeholderImg } from './assets/temp';
 
 import type { Theme } from '@material-ui/core/styles';
-import type { Asset } from './types';
 
-
-const placeholderImg = 'https://optinmonster.com/wp-content/uploads/2019/09/nonprofit-newsletter.png';
-const dumbyData: Asset[] = [1, 2, 3].map(num => ({
-    id: num,
-    title: `title ${num}`,
-    category: `category ${num}`,
-    datePosted: `datePosted ${num}`,
-    location: `location ${num}`,
-    img: placeholderImg,
-}));
 
 const useStyles = makeStyles((theme: Theme) => ({
     hero: {

--- a/client/src/NeedsAndOffers.tsx
+++ b/client/src/NeedsAndOffers.tsx
@@ -22,7 +22,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         '&:not(:last-child)': {
             marginRight: '20px',
         },
-        // marginRight: '20px',
     },
     cardImg: {
         borderRadius: '5px',

--- a/client/src/NeedsAndOffers.tsx
+++ b/client/src/NeedsAndOffers.tsx
@@ -63,9 +63,9 @@ function NeedsAndOffers(props: Props): JSX.Element {
                 {cards.map(card => (
                     <NavLink to={`/offer/${card.id}`} key={card.id} className={classes.card}>
                         <Card variant="outlined">
-                            <img src={card.img} className={classes.cardImg} alt={card.title} />
+                            <img src={card.imgs[0]} className={classes.cardImg} alt={card.title} />
                             <Typography variant="h6" component="h4" className={classes.cardText1}>
-                                {card.title}, {card.category}
+                                {card.title}, {card.categories[0]}
                             </Typography>
                             <div className={classes.cardText2}>
                                 <RoomOutlined />{card.location}<TodayOutlined />{card.datePosted}

--- a/client/src/NeedsAndOffers.tsx
+++ b/client/src/NeedsAndOffers.tsx
@@ -4,10 +4,11 @@ import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import TodayOutlined from '@material-ui/icons/TodayOutlined';
 import RoomOutlined from '@material-ui/icons/RoomOutlined';
+import { NavLink } from 'react-router-dom';
 
 import type { Theme } from '@material-ui/core/styles';
 
-import type { Assets } from './types';
+import type { Asset } from './types';
 
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -21,6 +22,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         '&:not(:last-child)': {
             marginRight: '20px',
         },
+        // marginRight: '20px',
     },
     cardImg: {
         borderRadius: '5px',
@@ -45,7 +47,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 type Props = {
   headerText: string,
-  cards: Assets,
+  cards: Asset[],
 };
 
 function NeedsAndOffers(props: Props): JSX.Element {
@@ -59,15 +61,17 @@ function NeedsAndOffers(props: Props): JSX.Element {
             </Typography>
             <div className={classes.needsAndOffersSub}>
                 {cards.map(card => (
-                    <Card className={classes.card} variant="outlined" key={card.id}>
-                        <img src={card.img} className={classes.cardImg} alt={card.title} />
-                        <Typography variant="h6" component="h4" className={classes.cardText1}>
-                            {card.title}, {card.category}
-                        </Typography>
-                        <div className={classes.cardText2}>
-                            <RoomOutlined />{card.location}<TodayOutlined />{card.datePosted}
-                        </div>
-                    </Card>
+                    <NavLink to={`/offer/${card.id}`} key={card.id} className={classes.card}>
+                        <Card variant="outlined">
+                            <img src={card.img} className={classes.cardImg} alt={card.title} />
+                            <Typography variant="h6" component="h4" className={classes.cardText1}>
+                                {card.title}, {card.category}
+                            </Typography>
+                            <div className={classes.cardText2}>
+                                <RoomOutlined />{card.location}<TodayOutlined />{card.datePosted}
+                            </div>
+                        </Card>
+                    </NavLink>
                 ))}
             </div>
         </>

--- a/client/src/Offer.tsx
+++ b/client/src/Offer.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { useParams } from "react-router-dom";
+// import * as queryString from 'query-string';
+import Paper from '@material-ui/core/Paper';
+import InputBase from '@material-ui/core/InputBase';
+import { NavLink } from 'react-router-dom';
+import SearchIcon from '@material-ui/icons/Search';
+import Button from '@material-ui/core/Button';
+import ArrowBackRoundedIcon from '@material-ui/icons/ArrowBackRounded';
+
+import type { Theme } from '@material-ui/core/styles';
+import type { Asset as AssetT } from './types';
+
+
+const placeholderImg = 'https://optinmonster.com/wp-content/uploads/2019/09/nonprofit-newsletter.png';
+const dumbyData: AssetT[] = [1, 2, 3].map(num => ({
+    id: num,
+    title: `title ${num}`,
+    category: `category ${num}`,
+    datePosted: `datePosted ${num}`,
+    location: `location ${num}`,
+    img: placeholderImg,
+}));
+
+const useStyles = makeStyles((theme: Theme) => ({
+    topBar: {
+        backgroundColor: 'white',
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        padding: '10px 5%',
+        borderRadius: 0,
+        alignItems: 'center',
+    },
+    searchInput: {
+        display: 'flex',
+        alignItems: 'center',
+        paddingLeft: '10px',
+    },
+    // TODO i'm just copying these from other files,
+    // either make them a component or make the styles shared objects somewhere
+    iconButton: {
+        padding: 10,
+        '&:hover': {
+            backgroundColor: 'inherit',
+            borderRadius: '10px',
+        },
+        textDecoration: 'none',
+    },
+    contentWrapper: {
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'flex-start',
+        padding: '10px 5%',
+    },
+    leftPanel: {
+      width: '50%',
+      flexGrow: 1,
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    rightPanel: {
+      width: '50%',
+      flexGrow: 1,
+      display: 'flex',
+      flexDirection: 'column',
+    },
+}));
+
+const useOffer = (id?: string): AssetT | null => {
+  const [offer, setOffer] = React.useState<AssetT | null>(null);
+
+  React.useEffect(() => {
+    if (!id) { return; }
+
+    // TODO replace find with fetch from BE
+    const newOffer = dumbyData.find(dd => dd.id === parseInt(id, 10));
+    setOffer(newOffer || null);
+  }, [id]);
+
+  return offer;
+};
+
+
+function Offer(): JSX.Element {
+    const classes = useStyles();
+    const { offerId } = useParams<{ offerId?: string }>();
+    const offer = useOffer(offerId);
+    const [searchText, setSearchText] = React.useState<string>('');
+
+    if (!offer) {
+      return <>offer not found</>;
+    }
+
+    return (
+        <>
+            <Paper className={classes.topBar}>
+                <NavLink to="/assets" className={classes.iconButton}>
+                    <Button><ArrowBackRoundedIcon />Go Back</Button>
+                </NavLink>
+                <Paper className={classes.searchInput}>
+                    <InputBase
+                        placeholder="ex. diapers"
+                        inputProps={{ 'aria-label': 'ex. diapers' }}
+                        type="text"
+                        value={searchText}
+                        onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => setSearchText(e.target.value)}
+                    />
+                    <NavLink to={`/assets?search=${searchText}`} className={classes.iconButton}>
+                        <SearchIcon />
+                    </NavLink>
+                </Paper>
+            </Paper>
+            <div className={classes.contentWrapper}>
+                <div className={classes.leftPanel}>
+                    left
+                </div>
+                <div className={classes.rightPanel}>
+                    right
+                </div>
+            </div>
+        </>
+    );
+}
+
+export default Offer;

--- a/client/src/Offer.tsx
+++ b/client/src/Offer.tsx
@@ -32,8 +32,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         alignItems: 'center',
         paddingLeft: '10px',
     },
-    // TODO i'm just copying these from other files,
-    // either make them a component or make the styles shared objects somewhere
     iconButton: {
         padding: 10,
         '&:hover': {

--- a/client/src/Offer.tsx
+++ b/client/src/Offer.tsx
@@ -1,27 +1,21 @@
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { useParams } from "react-router-dom";
-// import * as queryString from 'query-string';
 import Paper from '@material-ui/core/Paper';
 import InputBase from '@material-ui/core/InputBase';
 import { NavLink } from 'react-router-dom';
 import SearchIcon from '@material-ui/icons/Search';
 import Button from '@material-ui/core/Button';
 import ArrowBackRoundedIcon from '@material-ui/icons/ArrowBackRounded';
+import Typography from '@material-ui/core/Typography';
+import TodayOutlined from '@material-ui/icons/TodayOutlined';
+import RoomOutlined from '@material-ui/icons/RoomOutlined';
+
+import { dumbyData } from './assets/temp';
 
 import type { Theme } from '@material-ui/core/styles';
 import type { Asset as AssetT } from './types';
 
-
-const placeholderImg = 'https://optinmonster.com/wp-content/uploads/2019/09/nonprofit-newsletter.png';
-const dumbyData: AssetT[] = [1, 2, 3].map(num => ({
-    id: num,
-    title: `title ${num}`,
-    category: `category ${num}`,
-    datePosted: `datePosted ${num}`,
-    location: `location ${num}`,
-    img: placeholderImg,
-}));
 
 const useStyles = makeStyles((theme: Theme) => ({
     topBar: {
@@ -52,19 +46,56 @@ const useStyles = makeStyles((theme: Theme) => ({
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'flex-start',
-        padding: '10px 5%',
+        padding: '20px 15% 60px',
     },
     leftPanel: {
-      width: '50%',
-      flexGrow: 1,
-      display: 'flex',
-      flexDirection: 'column',
+        width: '60%',
+        marginRight: '5%',
+        flexGrow: 1,
+        display: 'flex',
+        flexDirection: 'column',
     },
     rightPanel: {
-      width: '50%',
-      flexGrow: 1,
-      display: 'flex',
-      flexDirection: 'column',
+        width: '35%',
+        flexGrow: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        textAlign: 'left',
+    },
+    imgs: {
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'flex-start',
+    },
+    miniImgs: {
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'flex-start',
+        width: '25%',
+    },
+    bigImg: {
+        minHeight: '300px',
+        minWidth: '300px',
+        marginRight: '5px',
+        borderRadius: '5px',
+        objectFit: 'cover',
+    },
+    miniImg: {
+        height: '50px',
+        width: '50px',
+        objectFit: 'cover',
+        borderRadius: '5px',
+        marginBottom: '10px',
+        cursor: 'pointer',
+    },
+    subText: {
+        display: 'flex',
+        paddingTop: '10px',
+        alignItems: 'center',
+    },
+    claimButton: {
+        marginTop: '20px',
+        width: '70%',
     },
 }));
 
@@ -87,15 +118,26 @@ function Offer(): JSX.Element {
     const classes = useStyles();
     const { offerId } = useParams<{ offerId?: string }>();
     const offer = useOffer(offerId);
+
     const [searchText, setSearchText] = React.useState<string>('');
+    const [selectedImgInd, setSelectedImgInd] = React.useState<number>(0);
+
+    const handleClaim = () => {
+      // TODOs
+      // post request to claim this offer for this user
+      // history.push to move us to confirmation page?
+      // trigger top banner to drop down that says 'claimed'?
+    }
 
     if (!offer) {
       return <>offer not found</>;
     }
 
+    const bigImg = offer.imgs[selectedImgInd];
+
     return (
         <>
-            <Paper className={classes.topBar}>
+            <Paper elevation={0} className={classes.topBar}>
                 <NavLink to="/assets" className={classes.iconButton}>
                     <Button><ArrowBackRoundedIcon />Go Back</Button>
                 </NavLink>
@@ -114,10 +156,47 @@ function Offer(): JSX.Element {
             </Paper>
             <div className={classes.contentWrapper}>
                 <div className={classes.leftPanel}>
-                    left
+                    <div className={classes.imgs}>
+                        <img src={bigImg} alt={offer.title} className={classes.bigImg} />
+                        <div className={classes.miniImgs}>
+                            {offer.imgs.map((img, ind) => ind !== selectedImgInd ? (
+                                <img
+                                    src={img}
+                                    alt={offer.title}
+                                    className={classes.miniImg}
+                                    onClick={() => setSelectedImgInd(ind)}
+                                />
+                            ) : null)}
+                        </div>
+                    </div>
+                    <p style={{ textAlign: 'left', padding: '20px 0' }}>
+                        {offer.description}
+                    </p>
                 </div>
                 <div className={classes.rightPanel}>
-                    right
+                    <Typography variant="h3">
+                        {offer.title}
+                    </Typography>
+                    <Typography className={classes.subText} variant="subtitle1">
+                        {offer.categories.join(', ')}
+                    </Typography>
+                    <Typography className={classes.subText} variant="subtitle1">
+                        Posted By {offer.postedBy}
+                    </Typography>
+                    <Typography className={classes.subText} variant="subtitle1">
+                        <RoomOutlined />{offer.location}
+                    </Typography>
+                    <Typography className={classes.subText} variant="subtitle1">
+                        <TodayOutlined />{offer.datePosted}
+                    </Typography>
+                    <Button
+                        color="primary"
+                        variant="contained"
+                        onClick={handleClaim}
+                        className={classes.claimButton}
+                    >
+                        Message to claim!
+                    </Button>
                 </div>
             </div>
         </>

--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -16,6 +16,7 @@ import TermsOfService from './TermsOfService';
 import PrivacyPolicy from './PrivacyPolicy';
 import CookiePolicy from './CookiePolicy';
 import Assets from './Assets';
+import Offer from './Offer';
 
 function Routes() {
     return (
@@ -67,6 +68,9 @@ function Routes() {
             </Route>
             <Route exact path="/assets">
                 <Assets />
+            </Route>
+            <Route exact path="/offer/:offerId">
+                <Offer />
             </Route>
         </Switch>
     );

--- a/client/src/assets/temp.ts
+++ b/client/src/assets/temp.ts
@@ -1,0 +1,27 @@
+import type { Asset } from '../types';
+
+
+export const placeholderImg = 'https://optinmonster.com/wp-content/uploads/2019/09/nonprofit-newsletter.png';
+const otherImg = 'https://s3.amazonaws.com/mentoring.redesign/s3fs-public/styles/aspect_ratio__4_3/public/nonprofit_biz_tool.jpg';
+
+const lorem = `
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+`;
+
+export const dumbyData: Asset[] = [1, 2, 3].map(num => ({
+    id: num,
+    title: `Title ${num}`,
+    categories: [1, 2, 3].map(n => `category ${n}`),
+    datePosted: `datePosted ${num}`,
+    location: `location ${num}`,
+    imgs: [placeholderImg, otherImg, otherImg],
+    description: lorem,
+    postedBy: 'User One',
+}));
+
+export const filters1 = ['filter 1', 'filter 2', 'filter 3'];
+export const filters2 = ['filter 4', 'filter 5', 'filter 6'];
+export const filters3 = ['filter 7', 'filter 8', 'filter 9'];

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,8 +1,11 @@
 export type Asset = {
     id: number,
     title: string,
-    category: string,
+    categories: string[],
     datePosted: string,
     location: string,
-    img: string,
+    imgs: string[],
+    description: string,
+    // TODO postedBy: User,
+    postedBy: string,
 };

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,8 +1,8 @@
-export type Assets = {
+export type Asset = {
     id: number,
     title: string,
     category: string,
     datePosted: string,
     location: string,
     img: string,
-}[];
+};


### PR DESCRIPTION
compare to offer page in mocks https://www.figma.com/file/fYkreARKdHsMh8iPSh7dti/Testing-File?node-id=0%3A1

1. http://localhost:3000/assets
2. click on one of the cards
3. see that you're on the offer page http://localhost:3000/offer/2
4. click on mini img and see that it moves to big img slot
5. click `go back` button, see assets page

not really sure if this page should really be `/assets/2`
but thought we would probs have separate need and offers pages so went with this
also went with primary button color for claim button, not sure why it looks disabled in mocks

<img width="1307" alt="Screen Shot 2021-06-19 at 10 33 16 AM" src="https://user-images.githubusercontent.com/16400333/122650818-c4a46e80-d0e9-11eb-861f-e0742a500b2d.png">
